### PR TITLE
gpio: gpio-ljca: rename gpio chip label

### DIFF
--- a/drivers/gpio/gpio-ljca.c
+++ b/drivers/gpio/gpio-ljca.c
@@ -430,7 +430,9 @@ static int ljca_gpio_probe(struct platform_device *pdev)
 
 	ljca_gpio->gc.base = -1;
 	ljca_gpio->gc.ngpio = ljca_gpio->ctr_info->num;
-	ljca_gpio->gc.label = "ljca-gpio";
+	ljca_gpio->gc.label = ACPI_COMPANION(&pdev->dev) ?
+			      acpi_dev_name(ACPI_COMPANION(&pdev->dev)) :
+			      "ljca-gpio";
 	ljca_gpio->gc.owner = THIS_MODULE;
 
 	platform_set_drvdata(pdev, ljca_gpio);


### PR DESCRIPTION
To make it compatible with INT3472, ACPI dev name are used as ljca gpio
chip label. For int3472 driver, it use lookup table to store the GPIO
pins config, which is parsing from DSDT. GPIO lookup table uses gpio
label to find gpio chip.

Signed-off-by: Ye Xiang <xiang.ye@intel.com>