### PR TITLE
ivsc usb and probe order fix

### DIFF
--- a/drivers/i2c/busses/i2c-ljca.c
+++ b/drivers/i2c/busses/i2c-ljca.c
@@ -427,7 +427,16 @@ static int ljca_i2c_probe(struct platform_device *pdev)
 		return -EIO;
 	}
 
-	return i2c_add_adapter(&ljca_i2c->adap);
+	ret = i2c_add_adapter(&ljca_i2c->adap);
+	if (ret)
+		return ret;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	if (has_acpi_companion(&ljca_i2c->adap.dev))
+		acpi_dev_clear_dependencies(ACPI_COMPANION(&ljca_i2c->adap.dev));
+#endif
+
+	return 0;
 }
 
 static int ljca_i2c_remove(struct platform_device *pdev)

--- a/drivers/mfd/ljca.c
+++ b/drivers/mfd/ljca.c
@@ -566,7 +566,7 @@ static void ljca_read_complete(struct urb *urb)
 			header->type, header->len);
 
 resubmit:
-	ret = usb_submit_urb(urb, GFP_KERNEL);
+	ret = usb_submit_urb(urb, GFP_ATOMIC);
 	if (ret)
 		dev_err(&ljca->intf->dev,
 			"failed submitting read urb, error %d\n", ret);


### PR DESCRIPTION
I have been working on making the ipu6-driver stack work on a Lenovo Thinkpad X1 Yoga gen 7 (alderlake) with a 6.0 kernel and using the INT3472 mainline kernel driver for power-control.

With the ipu6 code using acpi_dev_ready_for_enumeration() for kernel versions >= 5.17 ipu_psys_init() was returning -EPROBE_DEFER (and still does a number of time when letting udev automatically load the modules).

Getting  acpi_dev_ready_for_enumeration() to return true requires the ljca-i2c bus driver to call acpi_dev_clear_dependencies() to signal that the ACPI _DEV on it has been fulfilled / met.

While working on this I also noticed a kernel oops related to the ljca code calling a sleeping function from a non-sleeping kernel context. A fix for this is also included.

Together with https://github.com/intel/ipu6-drivers/pull/58 and [this](https://lore.kernel.org/linux-acpi/20221022150722.31787-1-hdegoede@redhat.com/) mainline kernel patch (+ the "standard" mainline patches) this results in a working camera on the Lenovo Thinkpad X1 Yoga gen 7 for me, with the modules autoloaded by udev and with the module load ordering not mattering.

Cc: @mrhpearson, @vicamo , @cjechlitschek