### PR TITLE
vsc: Defer firmware loading to avoid long probing time

### DIFF
--- a/drivers/misc/mei/hw-vsc.h
+++ b/drivers/misc/mei/hw-vsc.h
@@ -364,6 +364,7 @@ struct mei_vsc_hw {
 	u8 tx_buf1[MAX_XFER_BUFFER_SIZE];
 	u8 rx_buf1[MAX_XFER_BUFFER_SIZE];
 
+	struct work_struct probe_work;
 	struct mutex mutex;
 	bool disconnect;
 	atomic_t lock_cnt;


### PR DESCRIPTION
We are seeing long system boot time because vsc takes ~8 seconds to load firmware.

Though PROBE_PREFER_ASYNCHRONOUS flag is set by the driver, it only works when the module is loaded. Namely, using "modprobe mei-vsc" takes around 8 seconds to return to prompt as the module wasn't loaded beforehand.

Alternatively, we can use "mei-vsc.async_probe=1" to load module asynchronously. However, that doesn't work for boot time, because do_init_module() can enforce async_synchronize_full() for any subsequent module loading, essentially blocks all previous async loading.

There's also a global knob, "module.async_probe=1", to turn on async for all modules. But it's not the default for a reason - some modules panic with the option on. Until the implicit loading order gets fixed for all modules, "module.async_probe=1" won't be the default anytime soon.

Instead, use a deferred work for firmware loading part, to workaround the limitation Linux kernel currently imposes. Many sound drivers already use this approach for the their probe routine.