### PR TITLE
backport: update mei headers to v6.1

### DIFF
--- a/backport-include/drivers/misc/mei/hw.h
+++ b/backport-include/drivers/misc/mei/hw.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (c) 2003-2020, Intel Corporation. All rights reserved
+ * Copyright (c) 2003-2022, Intel Corporation. All rights reserved
  * Intel Management Engine Interface (Intel MEI) Linux driver
  */
 
@@ -17,11 +17,16 @@
 #define MEI_CONNECT_TIMEOUT         3  /* HPS: at least 2 seconds */
 
 #define MEI_CL_CONNECT_TIMEOUT     15  /* HPS: Client Connect Timeout */
+#define MEI_CL_CONNECT_TIMEOUT_SLOW 30 /* HPS: Client Connect Timeout, slow FW */
 #define MEI_CLIENTS_INIT_TIMEOUT   15  /* HPS: Clients Enumeration Timeout */
 
 #define MEI_PGI_TIMEOUT             1  /* PG Isolation time response 1 sec */
 #define MEI_D0I3_TIMEOUT            5  /* D0i3 set/unset max response time */
 #define MEI_HBM_TIMEOUT             1  /* 1 second */
+#define MEI_HBM_TIMEOUT_SLOW        5  /* 5 second, slow FW */
+
+#define MKHI_RCV_TIMEOUT 500 /* receive timeout in msec */
+#define MKHI_RCV_TIMEOUT_SLOW 10000 /* receive timeout in msec, slow FW */
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
 /*

--- a/drivers/misc/mei/hw-vsc.c
+++ b/drivers/misc/mei/hw-vsc.c
@@ -1627,7 +1627,11 @@ struct mei_device *mei_vsc_dev_init(struct device *parent)
 	if (!dev)
 		return NULL;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	mei_device_init(dev, parent, &mei_vsc_hw_ops);
+#else
+	mei_device_init(dev, parent, false, &mei_vsc_hw_ops);
+#endif
 	dev->fw_f_fw_ver_supported = 0;
 	dev->kind = 0;
 	return dev;


### PR DESCRIPTION
Closes: #26
Signed-off-by: You-Sheng Yang (vicamo) <vicamo.yang@canonical.com>