### PR TITLE
ljca: Null check acpi_dev to prevent null-ptr-deref bug

### DIFF
--- a/drivers/mfd/ljca.c
+++ b/drivers/mfd/ljca.c
@@ -265,6 +265,7 @@ static int match_device_ids(struct acpi_device *adev, void *data)
 static int precheck_acpi_hid(struct usb_interface *intf)
 {
 	struct device *parents[2];
+	struct acpi_device *adev;
 	int i;
 	int child_count;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
@@ -276,7 +277,11 @@ static int precheck_acpi_hid(struct usb_interface *intf)
 	if (!parents[0] || !parents[1])
 		return -ENODEV;
 
-	acpi_dev_clear_dependencies(ACPI_COMPANION(parents[0]));
+	adev = ACPI_COMPANION(parents[0]);
+	if (!adev)
+		return -ENODEV;
+
+	acpi_dev_clear_dependencies(adev);
 	sub_dev_parent = parents[0];
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)


### PR DESCRIPTION
Prevent null-ptr-deref in case the jlca does not have an ACPI companion.

Fixes: e1bb9fc0b477 (ljca: try to find acpi device from hub device)