### PR TITLE
media: mei_csi/mei_ace: Fix driver modalias not matching device modalias

### DIFF
--- a/drivers/misc/ivsc/mei_ace.c
+++ b/drivers/misc/ivsc/mei_ace.c
@@ -548,7 +548,7 @@ static void mei_ace_remove(struct mei_cl_device *cldev)
 			     0x9B, 0x78, 0x03, 0x61, 0x63, 0x5E, 0x24, 0x47)
 
 static const struct mei_cl_device_id mei_ace_tbl[] = {
-	{ MEI_ACE_DRIVER_NAME, MEI_UUID_ACE, MEI_CL_VERSION_ANY },
+	{ .uuid = MEI_UUID_ACE, .version = MEI_CL_VERSION_ANY },
 
 	/* required last entry */
 	{ }

--- a/drivers/misc/ivsc/mei_csi.c
+++ b/drivers/misc/ivsc/mei_csi.c
@@ -415,7 +415,7 @@ static void mei_csi_remove(struct mei_cl_device *cldev)
 			     0xAF, 0x93, 0x7b, 0x44, 0x53, 0xAC, 0x29, 0xDA)
 
 static const struct mei_cl_device_id mei_csi_tbl[] = {
-	{ MEI_CSI_DRIVER_NAME, MEI_UUID_CSI, MEI_CL_VERSION_ANY },
+	{ .uuid = MEI_UUID_CSI, .version = MEI_CL_VERSION_ANY },
 
 	/* required last entry */
 	{ }


### PR DESCRIPTION
This fixes an issue with the mei device-id matching which I noticed while debugging an out of tree IPU6 driver issue which a Fedora user was seeing with kernels >= 6.5 on a Dell Precision 5470 which uses the VSC chip.

Note the root cause there was a different issue and these patches have been compile tested only, please test.

This fix should allow dropping the:

```
MODULE_SOFTDEP("post: mei_csi mei_ace");
```

line in `drivers/misc/ivsc/intel_vsc.c` since the drivers should now properly get autoloaded by modprobe.

