### PR TITLE
spi-vsc: Call acpi_dev_clear_dependencies()

### DIFF
--- a/drivers/misc/mei/spi-vsc.c
+++ b/drivers/misc/mei/spi-vsc.c
@@ -123,6 +123,11 @@ static int get_sensor_name(struct mei_device *dev)
 		*c = tolower(*c);
 
 	ACPI_FREE(buffer.pointer);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+	acpi_dev_clear_dependencies(adev);
+#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
Since mainline kernel commit 7f6fd06d34f4 ("ACPI: scan: Defer enumeration of devices with a _DEP pointing to IVSC device") the i2c-client for sensors with an ACPI _DEP on the iVSC will no longer get instantiated until acpi_dev_clear_dependencies() is called for that _DEP.

Make get_sensor_name() which already looks-up a reference to the correct adev call acpi_dev_clear_dependencies(). For the out of tree version of the iVSC drivers when acpi_dev_clear_dependencies() is called exactly does not matter since sensor drivers explicitly call vsc_acquire_camera_sensor() before probing.

Note the LINUX_VERSION_CODE check is for >= 5.17 where acpi_dev_clear_dependencies() was introduced, rather then for >= 6.6 where the commit causing the trouble was introduced. This is done in case the troublesome commit gets backported. Calling acpi_dev_clear_dependencies() unnecessarily is not an issue.