### PR TITLE
ljca: gpio: add LNL support

### DIFF
--- a/drivers/mfd/ljca.c
+++ b/drivers/mfd/ljca.c
@@ -30,6 +30,7 @@ static char *gpio_hids[] = {
 	"INTC1096", /* ADL */
 	"INTC100B", /* RPL */
 	"INTC10D1", /* MTL */
+	"INTC10B5", /* LNL */
 };
 static struct mfd_cell_acpi_match ljca_acpi_match_gpio;
 


### PR DESCRIPTION
Adds LJCA GPIO support for LNL platform.