### PR TITLE
Ivsc kernel 6.8 fixes

### DIFF
--- a/drivers/gpio/gpio-ljca.c
+++ b/drivers/gpio/gpio-ljca.c
@@ -253,8 +253,8 @@ static void ljca_gpio_async(struct work_struct *work)
 	}
 }
 
-void ljca_gpio_event_cb(struct platform_device *pdev, u8 cmd,
-			const void *evt_data, int len)
+static void ljca_gpio_event_cb(struct platform_device *pdev, u8 cmd,
+			       const void *evt_data, int len)
 {
 	const struct gpio_packet *packet = evt_data;
 	struct ljca_gpio_dev *ljca_gpio = platform_get_drvdata(pdev);

--- a/drivers/mfd/ljca.c
+++ b/drivers/mfd/ljca.c
@@ -221,7 +221,7 @@ static int try_match_acpi_hid(struct acpi_device *child, char **hids, int hids_n
 	int i;
 
 	for (i = 0; i < hids_num; i++) {
-		strlcpy(ids[0].id, hids[i], sizeof(ids[0].id));
+		strscpy(ids[0].id, hids[i], sizeof(ids[0].id));
 		if (!acpi_match_device_ids(child, ids))
 			return i;
 	}

--- a/drivers/mfd/ljca.c
+++ b/drivers/mfd/ljca.c
@@ -320,7 +320,7 @@ static bool ljca_validate(void *data, u32 data_len)
 	return (header->len + sizeof(*header) == data_len);
 }
 
-void ljca_dump(struct ljca_dev *ljca, void *buf, int len)
+static void ljca_dump(struct ljca_dev *ljca, void *buf, int len)
 {
 	int i;
 	u8 tmp[256] = { 0 };

--- a/drivers/misc/ivsc/mei_ace.c
+++ b/drivers/misc/ivsc/mei_ace.c
@@ -311,21 +311,21 @@ static int set_camera_ownership(struct mei_ace *ace,
 	return ret;
 }
 
-int ipu_own_camera(void *ace, struct camera_status *status)
+static int ipu_own_camera(void *ace, struct camera_status *status)
 {
 	struct mei_ace *p_ace = (struct mei_ace *)ace;
 
 	return set_camera_ownership(p_ace, IPU_OWN_CAMERA, status);
 }
 
-int ace_own_camera(void *ace, struct camera_status *status)
+static int ace_own_camera(void *ace, struct camera_status *status)
 {
 	struct mei_ace *p_ace = (struct mei_ace *)ace;
 
 	return set_camera_ownership(p_ace, ACE_OWN_CAMERA, status);
 }
 
-int get_camera_status(void *ace, struct camera_status *status)
+static int get_camera_status(void *ace, struct camera_status *status)
 {
 	int ret;
 	struct ace_cmd cmd;

--- a/drivers/spi/spi-ljca.c
+++ b/drivers/spi/spi-ljca.c
@@ -210,10 +210,6 @@ static int ljca_spi_transfer(struct ljca_spi_dev *ljca_spi, const u8 *tx_data,
 static int ljca_spi_prepare_message(struct spi_master *master,
 				    struct spi_message *message)
 {
-	struct ljca_spi_dev *ljca_spi = spi_master_get_devdata(master);
-	struct spi_device *spi = message->spi;
-
-	dev_dbg(&ljca_spi->pdev->dev, "cs %d\n", spi->chip_select);
 	return 0;
 }
 


### PR DESCRIPTION
Here is a set of build + compiler warning fixes for making ivsc-drivers build with the upcoming 6.8 release.

Cc: @vicamo @smallorange 